### PR TITLE
Improve DX and make development easier

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,2 @@
+[alias]
+anonima = "run --bin anonima --"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -123,6 +123,7 @@ dependencies = [
  "rpassword",
  "serde",
  "structopt",
+ "temp-dir",
  "void",
  "wasm-timer",
 ]
@@ -3949,6 +3950,12 @@ dependencies = [
  "syn 1.0.69",
  "unicode-xid 0.2.1",
 ]
+
+[[package]]
+name = "temp-dir"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af547b166dd1ea4b472165569fc456cfb6818116f854690b0ff205e636523dab"
 
 [[package]]
 name = "tempfile"

--- a/anonima/Cargo.toml
+++ b/anonima/Cargo.toml
@@ -32,6 +32,7 @@ net_utils = { path = "../utils/net_utils" }
 num-bigint = { path = "../utils/bigint", package = "anonima_bigint" }
 address = { path = "../address", package = "anonima-address", version = "0.3" }
 anonima_libp2p = { path = "../network" }
+temp-dir = "0.1"
 
 [dependencies.jsonrpc-v2]
 version = "0.10.0"

--- a/anonima/src/cli/config.rs
+++ b/anonima/src/cli/config.rs
@@ -13,6 +13,8 @@ pub struct Config {
     pub enable_rpc: bool,
     pub rpc_port: String,
     pub encrypt_keystore: bool,
+    #[serde(skip)]
+    pub tmp_dir: Option<temp_dir::TempDir>,
 }
 
 impl Default for Config {
@@ -23,6 +25,19 @@ impl Default for Config {
             enable_rpc: true,
             rpc_port: "1234".to_string(),
             encrypt_keystore: false,
+            tmp_dir: None,
+        }
+    }
+}
+
+impl Config {
+    pub fn tmp() -> Self {
+        let mut cfg = Self::default();
+        let tmp_dir = temp_dir::TempDir::new().expect("failed to create temp dir");
+        Self {
+            data_dir: tmp_dir.path().display().to_string(),
+            tmp_dir: Some(tmp_dir),
+            ..Default::default()
         }
     }
 }

--- a/anonima/src/cli/mod.rs
+++ b/anonima/src/cli/mod.rs
@@ -40,7 +40,7 @@ pub struct DaemonOpts {
     pub port: Option<String>,
     #[structopt(short, long, help = "Allow Kademlia (default = true)")]
     pub kademlia: Option<bool>,
-    #[structopt(short, long, help = "Allow MDNS (default = false)")]
+    #[structopt(short, long, help = "Allow MDNS (default = true)")]
     pub mdns: Option<bool>,
     #[structopt(long, help = "Number of worker sync tasks spawned (default is 1")]
     pub worker_tasks: Option<usize>,
@@ -54,6 +54,12 @@ pub struct DaemonOpts {
         help = "Amount of Peers we want to be connected to (default is 75)"
     )]
     pub target_peer_count: Option<u32>,
+    #[structopt(
+        long,
+        help = "Use a temporary directory instead of data dir provided from config file.
+                useful for local testing"
+    )]
+    pub tmp: bool,
 }
 
 impl DaemonOpts {
@@ -67,6 +73,10 @@ impl DaemonOpts {
             }
             None => Config::default(),
         };
+
+        if self.tmp {
+            cfg = Config::tmp();
+        }
 
         if self.rpc.unwrap_or(cfg.enable_rpc) {
             cfg.enable_rpc = true;

--- a/anonima/src/cli/mod.rs
+++ b/anonima/src/cli/mod.rs
@@ -57,13 +57,21 @@ pub struct DaemonOpts {
     #[structopt(
         long,
         help = "Use a temporary directory instead of data dir provided from config file.
-                useful for local testing"
+        useful for local testing"
     )]
     pub tmp: bool,
+    #[structopt(long, help = "Enable development logging (default is false)")]
+    pub dev: bool,
 }
 
 impl DaemonOpts {
     pub fn to_config(&self) -> Result<Config, io::Error> {
+        let logger_env = if self.dev {
+            super::logger::LogEnv::Develoment
+        } else {
+            super::logger::LogEnv::Production
+        };
+        super::logger::setup_logger(logger_env);
         let mut cfg: Config = match &self.config {
             Some(config_file) => {
                 // Read from config file

--- a/anonima/src/logger.rs
+++ b/anonima/src/logger.rs
@@ -1,16 +1,37 @@
 use log::LevelFilter;
 
-pub(crate) fn setup_logger() {
+pub(crate) enum LogEnv {
+    Production,
+    Test,
+    Develoment,
+}
+
+pub(crate) fn setup_logger(env: LogEnv) {
     let mut logger_builder = pretty_env_logger::formatted_timed_builder();
     if let Ok(s) = ::std::env::var("RUST_LOG") {
         // Set log level based on filters if set
         logger_builder.parse_filters(&s);
     } else {
-        // If no ENV variable specified, default to info
-        logger_builder.filter(Some("anonima_gossipsub"), LevelFilter::Error);
-        logger_builder.filter(Some("anonima_bitswap"), LevelFilter::Warn);
-        logger_builder.filter(Some("rpc"), LevelFilter::Info);
-        logger_builder.filter(None, LevelFilter::Info);
+        match env {
+            LogEnv::Develoment => {
+                logger_builder.filter(Some("anonima"), LevelFilter::Debug);
+                logger_builder.filter(Some("key_management"), LevelFilter::Debug);
+                logger_builder.filter(Some("anonima_crypto"), LevelFilter::Debug);
+                logger_builder.filter(Some("anonima_address"), LevelFilter::Debug);
+                logger_builder.filter(Some("anonima_libp2p"), LevelFilter::Debug);
+                logger_builder.filter(Some("anonima_gossipsub"), LevelFilter::Debug);
+                logger_builder.filter(Some("anonima_bitswap"), LevelFilter::Debug);
+                logger_builder.filter(Some("rpc"), LevelFilter::Debug);
+                logger_builder.filter(None, LevelFilter::Info);
+            }
+            _ => {
+                // If no ENV variable specified, default to info
+                logger_builder.filter(Some("anonima_gossipsub"), LevelFilter::Error);
+                logger_builder.filter(Some("anonima_bitswap"), LevelFilter::Warn);
+                logger_builder.filter(Some("rpc"), LevelFilter::Info);
+                logger_builder.filter(None, LevelFilter::Info);
+            }
+        }
     }
     let logger = logger_builder.build();
 

--- a/anonima/src/main.rs
+++ b/anonima/src/main.rs
@@ -7,7 +7,6 @@ use structopt::StructOpt;
 
 #[async_std::main]
 async fn main() {
-    logger::setup_logger();
     // Capture CLI inputs
     match CLI::from_args() {
         CLI { daemon_opts } => daemon::start(daemon_opts.to_config().unwrap()).await,

--- a/network/src/behaviour.rs
+++ b/network/src/behaviour.rs
@@ -269,7 +269,6 @@ impl ForestBehaviour {
             .with_mdns(config.mdns)
             .with_kademlia(config.kademlia)
             .with_user_defined(config.bootstrap_peers.clone())
-            // TODO allow configuring this through config.
             .discovery_limit(config.target_peer_count as u64);
 
         let hp = std::iter::once((HelloProtocolName, ProtocolSupport::Full));

--- a/network/src/config.rs
+++ b/network/src/config.rs
@@ -26,7 +26,7 @@ impl Default for Libp2pConfig {
         Self {
             listening_multiaddr: "/ip4/0.0.0.0/tcp/0".parse().unwrap(),
             bootstrap_peers,
-            mdns: false,
+            mdns: true,
             kademlia: true,
             target_peer_count: 75,
         }

--- a/network/src/discovery.rs
+++ b/network/src/discovery.rs
@@ -369,6 +369,7 @@ impl NetworkBehaviour for DiscoveryBehaviour {
                         KademliaEvent::PendingRoutablePeer { .. } => {
                             // Intentionally ignore
                         }
+                        KademliaEvent::QueryResult { .. } => {}
                         other => {
                             debug!("Libp2p => Unhandled Kademlia event: {:?}", other)
                         }

--- a/network/src/discovery.rs
+++ b/network/src/discovery.rs
@@ -321,15 +321,15 @@ impl NetworkBehaviour for DiscoveryBehaviour {
     }
 
     #[allow(clippy::type_complexity)]
-	fn poll(
-		&mut self,
-		cx: &mut Context,
-		params: &mut impl PollParameters,
-	) -> Poll<
-		NetworkBehaviourAction<
-			<<Self::ProtocolsHandler as IntoProtocolsHandler>::Handler as ProtocolsHandler>::InEvent,
-			Self::OutEvent,
-		>,
+    fn poll(
+        &mut self,
+        cx: &mut Context,
+        params: &mut impl PollParameters,
+    ) -> Poll<
+        NetworkBehaviourAction<
+            <<Self::ProtocolsHandler as IntoProtocolsHandler>::Handler as ProtocolsHandler>::InEvent,
+            Self::OutEvent,
+            >,
     >{
         // Immediately process the content of `discovered`.
         if let Some(ev) = self.pending_events.pop_front() {

--- a/network/src/service.rs
+++ b/network/src/service.rs
@@ -110,12 +110,6 @@ impl Libp2pService {
         .connection_event_buffer_size(64)
         .build();
 
-        if let Some(addr) = Some("/ip4/127.0.0.1/tcp/44655") {
-            let remote = addr.parse().unwrap();
-            Swarm::dial_addr(&mut swarm, remote).unwrap();
-            println!("Dialed {}", addr);
-        }
-
         Swarm::listen_on(&mut swarm, config.listening_multiaddr).unwrap();
 
         // Bootstrap with Kademlia

--- a/network/src/service.rs
+++ b/network/src/service.rs
@@ -135,7 +135,7 @@ impl Libp2pService {
     pub async fn run(self) {
         let mut swarm_stream = self.swarm.fuse();
         let mut network_stream = self.network_receiver_in.fuse();
-        let mut interval = stream::interval(Duration::from_secs(15)).fuse();
+        let mut interval = stream::interval(Duration::from_secs(5)).fuse();
         let _pubsub_dkg_str = format!("{}/{}", PUBSUB_DKG_STR, self.network_name);
         let pubsub_msg_str = format!("{}/{}", PUBSUB_MSG_STR, self.network_name);
         loop {


### PR DESCRIPTION
This enables `mDNS` by default so it is easy for local development and the node now can automatically discover local peers without any other configuration required.

I added another option to use a `temp-dir` for local data so that you can create as many nodes and get them to work without any code changes (the temp dir gets automatically deleted on shutdown).

make it easier to run the node, now you just run it as the following:
```
$ cargo anonima --dev --tmp
```